### PR TITLE
Set memory limit for load command.

### DIFF
--- a/src/Nexway/SetupManager/Command/Config/LoadCommand.php
+++ b/src/Nexway/SetupManager/Command/Config/LoadCommand.php
@@ -2,6 +2,8 @@
 
 namespace Nexway\SetupManager\Command\Config;
 
+ini_set('memory_limit', '64M');
+
 use Nexway\SetupManager\Util\Helper\Parser;
 use Nexway\SetupManager\Util\Helper\Processor;
 use Nexway\SetupManager\Util\Helper\Utils;


### PR DESCRIPTION
Commit introduces:
Set memory limit for load command (needed for update product).

modified:   src/Nexway/SetupManager/Command/Config/LoadCommand.php
