### PR TITLE
Changes random order prefix generation policy to unique+random

### DIFF
--- a/src/Nexway/SetupManager/Util/Helper/Utils.php
+++ b/src/Nexway/SetupManager/Util/Helper/Utils.php
@@ -29,6 +29,18 @@ class Utils
     const CREATE_STORE_CONFIG_ACTION    = 'store/createconfig';
 
     /**
+     * @const int Start date (01.01.2015) for test order prefix counter
+     * @see ::generateRandomPrefix() below
+     */
+    const TEST_ORDER_PREFIX_DATE = 1420066800; // 01.01.2015
+
+    /**
+     * @const int Length of prefix in test orders
+     * @see ::generateRandomPrefix() below
+     */
+    const TEST_ORDER_PREFIX_LENGTH = 8;
+
+    /**
      * extracts config from squeezed form
      *
      * from
@@ -395,18 +407,22 @@ class Utils
     }
 
     /**
-     * generate random prefix for order number
+     * Generate unique and random prefix for order number
+     *
+     * Prefix is made up of two components: timestamp based and genuinely random.
+     * Timestamp is calculated from 01.01.2015 and converted to base 36 in upper case.
+     * It is then right padded with random upper case characters up to 8 characters.
+     *
+     * @see ::TEST_ORDER_PREFIX_DATE for start date
+     * @see ::TEST_ORDER_PREFIX_LENGTH for prefix length
+     *
+     * @return string
      */
     public function generateRandomOrderPrefix()
     {
-        $randomInt      = '';
-        $randomChars    = '';
-
-        for ($i = 0; $i < 3; $i++) {
-            $randomInt      .= rand(0, 9);
-            $randomChars    .= chr(rand(65, 90));
-        }
-
-        return $randomChars . $randomInt;
+        $counter = time() - self::TEST_ORDER_PREFIX_DATE;
+        $counterBase36 = strtoupper(base_convert($counter, 10, 36));
+        $randomComponent = chr(rand(65, 90)) . chr(rand(65, 90)) . chr(rand(65, 90));
+        return str_pad($counterBase36, self::TEST_ORDER_PREFIX_LENGTH, $randomComponent, STR_PAD_RIGHT);
     }
 }

--- a/tests/Nexway/SetupManager/Util/Helper/UtilsTest.php
+++ b/tests/Nexway/SetupManager/Util/Helper/UtilsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Nexway\SetupManager\Util\Helper;
+
+use Nexway\SetupManager\Util\Helper\Utils;
+
+/**
+ * Class UtilsTest
+ * @package Tests\Nexway\SetupManager\Util\Helper
+ *
+ * @author     Michał Rudnicki <mrudnicki@nexway.com>
+ * @copyright  Copyright (c) 2015 Nexway
+ *
+ * @coversDefaultClass Nexway\SetupManager\Util\Helper\Utils
+ */
+class UtilsTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @test
+     * @covers ::generateRandomOrderPrefix
+     */
+    public function generateRandomOrderPrefix()
+    {
+        $utils = new Utils();
+        $generated = $utils->generateRandomOrderPrefix();
+
+        $counter1 = time() - Utils::TEST_ORDER_PREFIX_DATE;
+        $counter2 = $counter1 - 1; // also check a second ago in case the clock has ticked
+        $counter1Base36 = strtoupper(base_convert($counter1, 10, 36));
+        $counter2Base36 = strtoupper(base_convert($counter2, 10, 36));
+        $match1 = 0 === strpos($generated, $counter1Base36);
+        $match2 = 0 === strpos($generated, $counter2Base36);
+
+        $this->assertTrue($match1 xor $match2);
+        $this->assertEquals(Utils::TEST_ORDER_PREFIX_LENGTH, strlen($generated));
+    }
+
+}


### PR DESCRIPTION
Purely random method of generating test order prefix was causing some nondeterministic failures in Totem runs. This commit changes the policy by adding unique, timestamp-based component and pads the order prefix string with random values.
