### PR TITLE
Update CMS page management

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "nexway/magerun-addons",
     "type": "magento-module",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "description": "Magerun addons: SetupManeger",
     "homepage": "http://nexway.com",
     "license": "MIT",

--- a/src/Nexway/SetupManager/Util/Helper/Parser.php
+++ b/src/Nexway/SetupManager/Util/Helper/Parser.php
@@ -73,6 +73,7 @@ class Parser
         'agreements'      => ['id', 'name'],
         'customer_group'  => ['id', 'customer_group_code'],
         'image'           => ['id', 'local', 'favicon', 'theme'],
+        'cms'             => ['identifier'],
     ];
 
     /**
@@ -80,7 +81,6 @@ class Parser
      *      by more than one field aka multicolumn unique key loader.
      */
     protected $_compundExtIdAllowed = [
-        'cms'   => [ ['identifier', 'store_id'] ],
         'group' => [ ['name', 'website_id'] ],
     ];
 

--- a/src/Nexway/SetupManager/Util/Processor/Action/Cms/Deleteall.php
+++ b/src/Nexway/SetupManager/Util/Processor/Action/Cms/Deleteall.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Nexway\SetupManager\Util\Processor\Action\Agreement;
+
+use Nexway\SetupManager\Util\Processor\AbstractAction;
+
+/**
+ *
+ * @category     Nexway
+ * @package      Nexway_SetupManager
+ * @author       Mariusz Tasak <mtasak@nexway.com>
+ * @copyright    Copyright (c) 2013-2014, Nexway
+ */
+class Deleteall extends AbstractAction
+{
+    protected function _deleteall()
+    {
+        $this->getParameters()->setModel('cms/page');
+        return parent::_deleteall();
+    }
+}


### PR DESCRIPTION
- allow deleteall action
- identifier is unique on Mage CMS (as opposite to JR_CleverCms)
- bump major version because this breaks compatibility